### PR TITLE
Git Submodule Setup for CDC Submission Configs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -107,3 +107,5 @@ tests/__pycache__
 /bin/__pycache__/
 /bin/__pycache__
 /bin/table2asn
+/bin/config_files
+/bin/config_files/

--- a/.gitignore
+++ b/.gitignore
@@ -104,8 +104,6 @@ tests/__pycache__
 
 /input_files/
 /input_files
-/bin/config_files/mpxv_config_kk.yaml
-/bin/config_files/
 /bin/__pycache__/
 /bin/__pycache__
 /bin/table2asn

--- a/.gitignore
+++ b/.gitignore
@@ -107,5 +107,3 @@ tests/__pycache__
 /bin/__pycache__/
 /bin/__pycache__
 /bin/table2asn
-/bin/config_files
-/bin/config_files/

--- a/.gitignore
+++ b/.gitignore
@@ -107,3 +107,5 @@ tests/__pycache__
 /bin/__pycache__/
 /bin/__pycache__
 /bin/table2asn
+/bin/config_files/
+/bin/config_files

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
-[submodule "bin/config_files"]
-	path = bin/config_files
-	url = https://git.biotech.cdc.gov/monkeypox/mpxv_annotation_submission_dev_configs.git
+[submodule "CDC Submission Configs"]
+	path = bin
+	url = git@git.biotech.cdc.gov:monkeypox/mpxv_annotation_submission_dev_configs.git
+

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "bin/config_files"]
+	path = bin/config_files
+	url = https://git.biotech.cdc.gov/monkeypox/mpxv_annotation_submission_dev.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "bin/config_files"]
 	path = bin/config_files
-	url = https://git.biotech.cdc.gov/monkeypox/mpxv_annotation_submission_dev.git
+	url = https://git.biotech.cdc.gov/monkeypox/mpxv_annotation_submission_dev_configs.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "CDC Submission Configs"]
-	path = bin
+	path = bin/config_files
 	url = git@git.biotech.cdc.gov:monkeypox/mpxv_annotation_submission_dev_configs.git
 

--- a/bin/default_config_files/MPOX_config.yml
+++ b/bin/default_config_files/MPOX_config.yml
@@ -1,0 +1,116 @@
+---
+general:
+  submission_directory: ''
+  submit_Genbank: 'True'
+  submit_GISAID: 'False'
+  submit_SRA: 'True'
+  submit_BioSample: 'True'
+  joint_SRA_BioSample_submission: 'False'
+  contact_email1: ''
+  contact_email2: ''
+  organization_name: ''
+  authorset:
+  - first: ''
+    last: ''
+    middle: ''
+    initials: ''
+    suffix: ''
+    title: ''
+  - first: ''
+    last: ''
+    middle: ''
+    initials: ''
+    suffix: ''
+    title: ''
+  ncbi_org_id: ''
+  submitter_info:
+    first: ''
+    last: ''
+    middle: ''
+    initials: ''
+    suffix: ''
+    title: ''
+  organism_name: 
+  metadata_file_sep: ''
+  fasta_sample_name_col: 'sample_name'
+  collection_date_col: 'collection_date'
+  baseline_surveillance: 'True'
+ncbi:
+  hostname: ftp-private.ncbi.nlm.nih.gov
+  api_url: https://submit.ncbi.nlm.nih.gov/api/2.0/files/FILE_ID/?format=attachment
+  username: ''
+  password: ''
+  publication_title: ''
+  ncbi_ftp_path_to_submission_folders: ''
+  BioProject: ''
+  BioSample_sample_name_col: 'ncbi_sequence_name_biosample_genbank'
+  SRA_sample_name_col: 'ncbi_sequence_name_sra'
+  Genbank_sample_name_col: 'ncbi_sequence_name_biosample_genbank'
+  BioSample_package: 
+  Center_title: ''
+  Genbank_organization_type: center
+  Genbank_organization_role: owner
+  Genbank_spuid_namespace: 
+  Genbank_auto_remove_sequences_that_fail_qc: 'True'
+  Genbank_wizard: 
+  citation_address:
+    affil: ''
+    div: ''
+    city: ''
+    sub: ''
+    country: ''
+    street: ''
+    postal-code: ''
+    email: ''
+    phone: ''
+  SRA_file_location: 
+  SRA_file_column1: 'sra_file_path_1'
+  SRA_file_column2: 'sra_file_path_2'
+genbank_src_metadata:
+  column_names:
+    isolate: isolate
+    country: geo_location
+    host: host
+    isolation-source: sample_type
+genbank_cmt_metadata:
+  create_cmt: 'True'
+  column_names:
+    StructuredCommentPrefix: structuredcomment
+    Assembly Method: assembly_method
+    Sequencing Technology: sequencing_instrument
+    StructuredCommentSuffix: StructuredComment
+BioSample_attributes:
+  column_names:
+    organism: organism
+    isolate: ncbi_sequence_name_biosample_genbank
+    collected_by: collected_by
+    geo_loc_name: geo_location
+    host: host
+    host_disease: host_disease
+    lat_lon: lat_lon
+    
+SRA_attributes:
+  column_names:
+    assembly: assembly_protocol
+    library_construction_protocol: library_protocol
+    library_strategy: library_strategy
+    library_source: library_source
+    library_selection: library_selection
+    library_layout: library_protocol
+    instrument_model: sequencing_instrument
+    
+gisaid:
+  column_names:
+    covv_location: geo_location
+    covv_host: host
+    covv_gender: sex
+    covv_patient_age: age
+    covv_specimen: sample_type
+    covv_seq_technology: sequencing_instrument
+    covv_assembly_method: assembly_method
+  gisaid_sample_name_col: 'ncbi_sequence_name_biosample_genbank'
+  cid: 
+  username: ''
+  password: ''
+  type: 
+  Update_sequences_on_Genbank_auto_removal: 'True'

--- a/bin/default_config_files/default_config.yaml
+++ b/bin/default_config_files/default_config.yaml
@@ -1,0 +1,96 @@
+---
+general:
+  submission_directory: ''
+  submit_Genbank: 'True'
+  submit_GISAID: 'True'
+  submit_SRA: 'False'
+  submit_BioSample: 'True'
+  joint_SRA_BioSample_submission: 'True'
+  contact_email1: ''
+  contact_email2: ''
+  organization_name: ''
+  authorset:
+  - first: ''
+    last: ''
+    middle: ''
+    initials: ''
+    suffix: ''
+    title: ''
+  - first: ''
+    last: ''
+    middle: ''
+    initials: ''
+    suffix: ''
+    title: ''
+  ncbi_org_id: ''
+  submitter_info:
+    first: ''
+    last: ''
+    middle: ''
+    initials: ''
+    suffix: ''
+    title: ''
+  organism_name: Severe acute respiratory syndrome coronavirus 2
+  metadata_file_sep: ''
+  fasta_sample_name_col: ''
+  collection_date_col: ''
+  baseline_surveillance: 'True'
+ncbi:
+  hostname: ftp-private.ncbi.nlm.nih.gov
+  api_url: https://submit.ncbi.nlm.nih.gov/api/2.0/files/FILE_ID/?format=attachment
+  username: ''
+  password: ''
+  publication_title: ''
+  ncbi_ftp_path_to_submission_folders: ''
+  BioProject: ''
+  BioSample_sample_name_col: ''
+  SRA_sample_name_col: ''
+  Genbank_sample_name_col: ''
+  BioSample_package: SARS-CoV-2.cl.1.0
+  Center_title: ''
+  Genbank_organization_type: center
+  Genbank_organization_role: owner
+  Genbank_spuid_namespace: ncbi-sarscov2-genbank
+  Genbank_auto_remove_sequences_that_fail_qc: 'True'
+  Genbank_wizard: BankIt_SARSCoV2_api
+  citation_address:
+    affil: ''
+    div: ''
+    city: ''
+    sub: ''
+    country: ''
+    street: ''
+    postal-code: ''
+    email: ''
+    phone: ''
+  SRA_file_location: Cloud
+  SRA_file_column1: ''
+  SRA_file_column2: ''
+  SRA_file_loader: ''
+genbank_src_metadata:
+  column_names:
+    database_field1: metadata_column
+    database_field2: metadata_column
+genbank_cmt_metadata:
+  create_cmt: 'True'
+  column_names:
+    database_field1: metadata_column
+    database_field2: metadata_column
+BioSample_attributes:
+  column_names:
+    database_field1: metadata_column
+    database_field2: metadata_column
+SRA_attributes:
+  column_names:
+    database_field1: metadata_column
+    database_field2: metadata_column
+gisaid:
+  column_names:
+    database_field1: metadata_column
+    database_field2: metadata_column
+  gisaid_sample_name_col: ''
+  cid: TEST-EA76875B00C3
+  username: ''
+  password: ''
+  type: betacoronavirus
+  Update_sequences_on_Genbank_auto_removal: 'True'

--- a/bin/default_config_files/required_columns.yaml
+++ b/bin/default_config_files/required_columns.yaml
@@ -1,0 +1,16 @@
+---
+Genbank:
+  required_src_columns:
+  - sequence_ID
+  - organism
+  - isolate
+  - collection-date
+  - host
+  - country
+  required_cmt_columns:
+  - SeqID
+  - StructuredCommentPrefix
+  - StructuredCommentSuffix
+Gisaid: []
+BioSample: []
+SRA: []

--- a/bin/run_submission.py
+++ b/bin/run_submission.py
@@ -3,7 +3,7 @@ import os
 import glob
 import subprocess
 import yaml
-
+ 
 def get_args():
     """ All potential arguments passed in through command line
     """

--- a/docs/cdc_configs_access.md
+++ b/docs/cdc_configs_access.md
@@ -5,18 +5,18 @@
 
 ### If You Do Not Have the Tostadas Repository Cloned, There are Two Options to Initialize the Submodule and Retrieve the Submission Config Files:
 
-#### (1) Clone and Initialize Separately
+### (1) Clone and Initialize Separately
 ```
 git clone https://github.com/CDCgov/tostadas.git && cd tostadas/bin && git submodule init && git submodule update 
 ```
 
 OR 
 
-#### (2) Clone with Initialization
+### (2) Clone with Initialization
 ```
 git clone --recurse-submodules https://github.com/CDCgov/tostadas.git
 ```
-#### You should now have the latest submission config files available within bin/config_files
+### You should now have the latest submission config files available within bin/config_files
 
 ### If You Already Have Tostadas Cloned Locally + Want to Update with Latest Remote Changes, You Can Either Use the Following Command Every Time:
 ```

--- a/docs/cdc_configs_access.md
+++ b/docs/cdc_configs_access.md
@@ -3,26 +3,26 @@
 
 ## Setup Instructions:
 
-#### If You Do Not Have the Tostadas Repository Cloned, There are Two Options to Initialize the Submodule and Retrieve the Submission Config Files:
+### If You Do Not Have the Tostadas Repository Cloned, There are Two Options to Initialize the Submodule and Retrieve the Submission Config Files:
 
-##### (1) Clone and Initialize Separately
+#### (1) Clone and Initialize Separately
 ```
 git clone https://github.com/CDCgov/tostadas.git && cd tostadas/bin && git submodule init && git submodule update 
 ```
 
 OR 
 
-##### (2) Clone with Initialization
+#### (2) Clone with Initialization
 ```
 git clone --recurse-submodules https://github.com/CDCgov/tostadas.git
 ```
-##### You should now have the latest submission config files available within bin/config_files
+#### You should now have the latest submission config files available within bin/config_files
 
-#### If You Already Have Tostadas Cloned Locally + Want to Update with Latest Remote Changes, You Can Either Use the Following Command Every Time:
+### If You Already Have Tostadas Cloned Locally + Want to Update with Latest Remote Changes, You Can Either Use the Following Command Every Time:
 ```
 git submodule update --remote
 ```
-#### Or Permanently Modify the Git Config to Update with Remote Changes Every Time You Use ``` git pull ```
+### Or Permanently Modify the Git Config to Update with Remote Changes Every Time You Use ``` git pull ```
 ```
 git config --global submodule.recurse true
 ```

--- a/docs/cdc_configs_access.md
+++ b/docs/cdc_configs_access.md
@@ -7,10 +7,10 @@
 
 ### (1) Clone and Initialize Separately
 ```
-git clone https://github.com/CDCgov/tostadas.git && cd tostadas/bin && git submodule init && git submodule update 
+git clone https://github.com/CDCgov/tostadas.git && cd tostadas/bin && git submodule init && git submodule update --remote
 ```
 
-OR 
+#### OR 
 
 ### (2) Clone with Initialization
 ```

--- a/docs/cdc_configs_access.md
+++ b/docs/cdc_configs_access.md
@@ -1,0 +1,36 @@
+# Access Submission Configs on CDC Gitlab
+
+
+## Setup Instructions:
+
+#### If You Do Not Have the Tostadas Repository Cloned, There are Two Options to Initialize the Submodule and Retrieve the Submission Config Files:
+
+##### (1) Clone and Initialize Separately
+```
+git clone https://github.com/CDCgov/tostadas.git && cd tostadas/bin && git submodule init && git submodule update 
+```
+
+OR 
+
+##### (2) Clone with Initialization
+```
+git clone --recurse-submodules https://github.com/CDCgov/tostadas.git
+```
+##### You should now have the latest submission config files available within bin/config_files
+
+#### If You Already Have Tostadas Cloned Locally + Want to Update with Latest Remote Changes, You Can Either Use the Following Command Every Time:
+```
+git submodule update --remote
+```
+#### Or Permanently Modify the Git Config to Update with Remote Changes Every Time You Use ``` git pull ```
+```
+git config --global submodule.recurse true
+```
+
+## More Information:
+
+:link: Internal Repository: https://git.biotech.cdc.gov/monkeypox/mpxv_annotation_submission_dev_configs.git 
+
+** Must have access to the Monkeypox group through CDC credentials **
+
+


### PR DESCRIPTION
Overview of Changes:
Created/initialized .gitmodules file and pushed to Tostadas repository for incorporating submission configuration files from a separate private repository in Gitlab. Added documentation under docs/ explaining how to clone the repository with submodules present and activated + how to update your local cloned version with the latest remote changes. 

How to Test:
Follow the instructions under docs within the submodule-setup branch. 
Test the following approaches from the document: 
(1) Cloning a new version of the Tostadas repository to local with submodules present and initialized, where you run: **git clone https://github.com/CDCgov/tostadas.git** and then **git checkout submodule-setup** and then **cd tostadas/bin && git submodule init && git submodule update --remote**
(2) If possible, using an existing older version of the Tostadas repository, where you run: **git config --global submodule.recurse true**  and then **git pull**
(3) If possible, using an existing older version of the Tostadas repository, where you first pull the latest changes, and then switch branches to submodule-setup, followed by running: **git submodule init** and then **git submodule update --remote**

Since the submodule is restricted to the submodule-setup branch for this PR, you need to checkout the submodule-setup branch before initializing and fetching remote updates. 