### PR TITLE
Fix null path error for submission

### DIFF
--- a/modules/local/initial_submission/main_genbank.nf
+++ b/modules/local/initial_submission/main_genbank.nf
@@ -14,7 +14,7 @@ process SUBMISSION_GENBANK {
         'cdcgov/seqsender-dev' : 'cdcgov/seqsender-dev' }"
 
     input:
-    tuple val(meta), path(validated_meta_path), path(fasta_path), val(fastq_1), val(fastq_2), path(annotations_path)
+    tuple val(meta), path(validated_meta_path), path(fasta_path), path(annotations_path)
     path submission_config
 
     // define the command line arguments based on the value of params.submission_test_or_prod, params.send_submission_email

--- a/modules/local/initial_submission/main_genbank.nf
+++ b/modules/local/initial_submission/main_genbank.nf
@@ -14,7 +14,7 @@ process SUBMISSION_GENBANK {
         'cdcgov/seqsender-dev' : 'cdcgov/seqsender-dev' }"
 
     input:
-    tuple val(meta), path(validated_meta_path), path(fasta_path), path(fastq_1), path(fastq_2), path(annotations_path)
+    tuple val(meta), path(validated_meta_path), path(fasta_path), val(fastq_1), val(fastq_2), path(annotations_path)
     path submission_config
 
     // define the command line arguments based on the value of params.submission_test_or_prod, params.send_submission_email

--- a/modules/local/initial_submission/main_sra.nf
+++ b/modules/local/initial_submission/main_sra.nf
@@ -14,7 +14,7 @@ process SUBMISSION_SRA {
         'cdcgov/seqsender-dev' : 'cdcgov/seqsender-dev'  }"
 
     input:
-    tuple val(meta), path(validated_meta_path), val(fasta_path), path(fastq_1), path(fastq_2)
+    tuple val(meta), path(validated_meta_path), path(fastq_1), path(fastq_2)
     path submission_config
 
     // define the command line arguments based on the value of params.submission_test_or_prod

--- a/modules/local/initial_submission/main_sra.nf
+++ b/modules/local/initial_submission/main_sra.nf
@@ -14,7 +14,7 @@ process SUBMISSION_SRA {
         'cdcgov/seqsender-dev' : 'cdcgov/seqsender-dev'  }"
 
     input:
-    tuple val(meta), path(validated_meta_path), path(fasta_path), path(fastq_1), path(fastq_2)
+    tuple val(meta), path(validated_meta_path), val(fasta_path), path(fastq_1), path(fastq_2)
     path submission_config
 
     // define the command line arguments based on the value of params.submission_test_or_prod

--- a/subworkflows/local/submission.nf
+++ b/subworkflows/local/submission.nf
@@ -23,6 +23,7 @@ workflow INITIAL_SUBMISSION {
         // submit the files to database of choice (after fixing config and getting wait time)
         if ( params.genbank && params.sra ){ // genbank and sra
             // submit the files to database of choice (after fixing config and getting wait time)
+            submission_ch.view()
             SUBMISSION_FULL ( submission_ch, submission_config )
             
             // actual process to initiate wait 
@@ -33,7 +34,14 @@ workflow INITIAL_SUBMISSION {
         }
 
         if ( !params.genbank && params.sra ){ //only sra
+            // drop fasta_path from ch
+            submission_ch = submission_ch
+                .map { 
+                    it -> [it[0], it[1], it[3], it[4]] 
+                }
+            submission_ch.view()
             SUBMISSION_SRA ( submission_ch, submission_config )
+            
             // actual process to initiate wait 
             WAIT ( SUBMISSION_SRA.out.submission_files.collect(), wait_time )
 
@@ -42,7 +50,12 @@ workflow INITIAL_SUBMISSION {
         }
 
         if ( params.genbank && !params.sra ){ //only genbank
-        // submit the files to database of choice (after fixing config and getting wait time)
+            // drop fastq paths
+            submission_ch = submission_ch
+                .map { 
+                    it -> [it[0], it[1], it[2], it[5]] 
+                }
+            submission_ch.view()
             SUBMISSION_GENBANK ( submission_ch, submission_config )
             
             // actual process to initiate wait 

--- a/subworkflows/local/submission.nf
+++ b/subworkflows/local/submission.nf
@@ -53,9 +53,8 @@ workflow INITIAL_SUBMISSION {
             // drop fastq paths
             submission_ch = submission_ch
                 .map { 
-                    it -> [it[0], it[1], it[2], it[5]] 
+                    meta, _, fq1, fq2 -> [meta, fq1, fq2] 
                 }
-            submission_ch.view()
             SUBMISSION_GENBANK ( submission_ch, submission_config )
             
             // actual process to initiate wait 


### PR DESCRIPTION
## Description
Modified the submission local modules to take val instead of path for unused parts of submission ch (tuple). For example, for sra submission, I changed fasta_path to val and then for genbank submission I changed the fastq inputs to val. These aren't used by the modules but this little hack avoids the null path error. 

## Checklist

**Go Through Checklist Below and Place A :heavy_check_mark: (X Inside the Box) if Completed**

#### General Checks

* [X] Have you run appropriate tests (unit/integration/end-to-end) to check logic across run environments (Conda/Docker/Singularity on Scicomp/AWS/NF Tower/Local)?

    
    For each relevant configuration:

    * Can the program run completely through without erroring out?
    * Does it produce the expected outputs, given the inputs provided? 

* [X] Have you conducted proper linting procedures?
    * Numpy formatted docstrings for functions
    * Comments explaining lines of code
    * Consistent and intuitive naming conventions for variables, functions, classes, methods, attributes, and scripts
    * Single empty line between class functions, two lines between non-class functions, and two lines between imports and code body
    * Camel case formatting for class names

* [X] Have you updated existing documentation (README.md, etc.) or created new ones within docs?

#### CDC Checks

* [X] Did you check for sensitive data, and remove any?
* [X] If you added or modified HTML, did you check that it was 508 compliant?

Are additional approvals needed for this change? If so, please mention them below:

Are there potential vulnerabilities or licensing issues with any new dependencies introduced? If so, please mention them below:




