### PR TITLE
allow submission to run without fasta file.

### DIFF
--- a/modules/local/initial_submission/main.nf
+++ b/modules/local/initial_submission/main.nf
@@ -32,7 +32,7 @@ process SUBMISSION {
         --metadata_file $validated_meta_path \
         --species $params.species \
         --output_dir  . \
-        --fasta_file $fasta_path \
+        ${fasta_path ? "--fasta_file $fasta_path" : ""} \
         ${annotations_path ? "--annotation_file $annotations_path" : ""} \
         ${fastq_1 ? "--fastq1 $fastq_1" : ""} \
         ${fastq_2 ? "--fastq2 $fastq_2" : ""} \


### PR DESCRIPTION
## Description

Fixes #239 

When not submitting to genbank, fasta file is not needed. Missing fasta file caused arg parsing error that --fasta_file cannot have no input
