### PR TITLE
Rework update submissions to allow re-submissions

### DIFF
--- a/bin/submission_new.py
+++ b/bin/submission_new.py
@@ -158,10 +158,10 @@ def submission_main():
 		report_csv_file = f"{parameters['output_dir']}/{parameters['submission_name']}/submission_report.csv"
 		if os.path.exists(report_csv_file):
 			# If file exists, append to it without writing the header
-			all_reports.to_csv(report_file, mode='a', header=False, index=False)
+			all_reports.to_csv(report_csv_file, mode='a', header=False, index=False)
 		else:
 			# If file doesn't exist, write it with the header
-			all_reports.to_csv(report_file, mode='w', header=True, index=False)
+			all_reports.to_csv(report_csv_file, mode='w', header=True, index=False)
 	
 	elif parameters['update']:
 		# Call and run the update submission script

--- a/bin/submission_new.py
+++ b/bin/submission_new.py
@@ -457,7 +457,7 @@ class Submission:
 			print(f"Report not found: {report_path}")
 		except ET.ParseError:
 			print(f"Error parsing XML report: {report_path}")
-		return consolidated_report
+		return pd.DataFrame([consolidated_report])
 	def submit_files(self, files, type):
 		""" Uploads a set of files to a host site at submit/<Test|Prod>/sample_database/<files> """
 		sample_subtype_dir = f'{self.sample.sample_id}_{type}' # samplename_<biosample,sra,genbank> (a unique submission dir)

--- a/bin/submission_new.py
+++ b/bin/submission_new.py
@@ -747,10 +747,9 @@ class SRASubmission(XMLSubmission, Submission):
 
 	def add_attributes_block(self, submission):
 		add_files = submission.find(".//AddFiles")
-		attributes = ET.SubElement(add_files, 'Attributes')
 		for attr_name, attr_value in self.sra_metadata.items():
 			if attr_value != "Not Provided":
-				attribute = ET.SubElement(attributes, 'Attribute', {'attribute_name': attr_name})
+				attribute = ET.SubElement(add_files, 'Attribute', {'name': attr_name})
 				attribute.text = self.safe_text(attr_value)
 		spuid_namespace_value = self.safe_text(self.top_metadata['ncbi-spuid_namespace'])
 		attribute_ref_id_bioproject = ET.SubElement(add_files, "AttributeRefId", name="BioProject")

--- a/bin/submission_new.py
+++ b/bin/submission_new.py
@@ -444,17 +444,27 @@ class Submission:
 			# Iterate over each <Action> element to extract database-specific data
 			for action in root.findall("Action"):
 				db = action.get("target_db", "").lower()
+				response = action.find("Response")
+				response_message = None
+				if response is not None:
+					# Extract message from <Message> tag if present
+					message_tag = response.find("Message")
+					if message_tag is not None:
+						response_message = message_tag.text.strip()
+					else:
+						# Fallback to Response's own text or attributes
+						response_message = response.get("status", "").strip() or response.text.strip()
 				if db == "biosample":
 					report['biosample_status'] = action.get("status", None)
-					report['biosample_message'] = action.findtext("Response")
+					report['biosample_message'] = response_message
 				elif db == "sra":
 					report['sra_status'] = action.get("status", None)
-					report['sra_message'] = action.findtext("Response")
+					report['sra_message'] = response_message
 				elif db == "genbank":
 					report['genbank_status'] = action.get("status", None)
-					report['genbank_message'] = action.findtext("Response")
+					report['genbank_message'] = response_message
 					report['genbank_release_date'] = action.get("release_date", None)
-			# Add tracking location if available
+			# Add server location if available
 			tracking_location = root.find("Tracking/SubmissionLocation")
 			if tracking_location is not None:
 				report['tracking_location'] = tracking_location.text

--- a/bin/submission_new.py
+++ b/bin/submission_new.py
@@ -413,7 +413,7 @@ class Submission:
 		Returns a DataFrame with one row per submission_name.
 		"""
 		# Initialize a dictionary to store consolidated data
-		consolidated_report = {
+		report = {
 			'submission_name': self.sample.sample_id,
 			'submission_status': None,
 			'submission_id': None,
@@ -434,30 +434,30 @@ class Submission:
 			tree = ET.parse(report_path)
 			root = tree.getroot()
 			# Extract submission-wide attributes
-			consolidated_report['submission_status'] = root.get("status", None)
-			consolidated_report['submission_id'] = root.get("submission_id", None)
+			report['submission_status'] = root.get("status", None)
+			report['submission_id'] = root.get("submission_id", None)
 			# Iterate over each <Action> element to extract database-specific data
 			for action in root.findall("Action"):
 				db = action.get("target_db", "").lower()
 				if db == "biosample":
-					consolidated_report['biosample_status'] = action.get("status", None)
-					consolidated_report['biosample_message'] = action.findtext("Response")
+					report['biosample_status'] = action.get("status", None)
+					report['biosample_message'] = action.findtext("Response")
 				elif db == "sra":
-					consolidated_report['sra_status'] = action.get("status", None)
-					consolidated_report['sra_message'] = action.findtext("Response")
+					report['sra_status'] = action.get("status", None)
+					report['sra_message'] = action.findtext("Response")
 				elif db == "genbank":
-					consolidated_report['genbank_status'] = action.get("status", None)
-					consolidated_report['genbank_message'] = action.findtext("Response")
-					consolidated_report['genbank_release_date'] = action.get("release_date", None)
+					report['genbank_status'] = action.get("status", None)
+					report['genbank_message'] = action.findtext("Response")
+					report['genbank_release_date'] = action.get("release_date", None)
 			# Add tracking location if available
 			tracking_location = root.find("Tracking/SubmissionLocation")
 			if tracking_location is not None:
-				consolidated_report['tracking_location'] = tracking_location.text
+				report['tracking_location'] = tracking_location.text
 		except FileNotFoundError:
 			print(f"Report not found: {report_path}")
 		except ET.ParseError:
 			print(f"Error parsing XML report: {report_path}")
-		return pd.DataFrame([consolidated_report])
+		return pd.DataFrame([report])
 	def submit_files(self, files, type):
 		""" Uploads a set of files to a host site at submit/<Test|Prod>/sample_database/<files> """
 		sample_subtype_dir = f'{self.sample.sample_id}_{type}' # samplename_<biosample,sra,genbank> (a unique submission dir)

--- a/conf/test_params.config
+++ b/conf/test_params.config
@@ -146,9 +146,11 @@ params {
         submission_mode                = 'ftp' // 'ftp' or 'sftp'
         submission_output_dir          = "submission_outputs"
         submission_prod_or_test        = "test" // "prod" if submitting
+        submission_config              = "${projectDir}/bin/config_files/mpxv_config.yaml" 
         submission_wait_time           = 380
         send_submission_email          = false
-        submission_config              = "${projectDir}/bin/config_files/mpxv_config.yaml" 
+        update_submission      = false
+        fetch_reports_only     = false // only try to fetch reports
         // batch_name                     = "batch1"
 
         // for update_submission:

--- a/modules/local/fetch_submission/main.nf
+++ b/modules/local/fetch_submission/main.nf
@@ -1,10 +1,9 @@
 /*
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-                            RUNNING SUBMISSION
+                                    FETCH SUBMISSION
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 */
-
-process SUBMISSION {
+process FETCH_SUBMISSION {
 
     publishDir "$params.output_dir/$params.submission_output_dir", mode: 'copy', overwrite: params.overwrite_output
 
@@ -13,6 +12,7 @@ process SUBMISSION {
         'staphb/tostadas:latest' : 'staphb/tostadas:latest' }"
 
     input:
+    val wait_time
     tuple val(meta), path(validated_meta_path), path(fasta_path), path(fastq_1), path(fastq_2), path(annotations_path)
     path submission_config
 
@@ -26,7 +26,7 @@ process SUBMISSION {
     script:
     """     
     submission_new.py \
-        --submit \
+        --fetch \
         --submission_name $meta.id \
         --config_file $submission_config  \
         --metadata_file $validated_meta_path \
@@ -45,5 +45,5 @@ process SUBMISSION {
     """
     output:
     path "${validated_meta_path.getBaseName()}", emit: submission_files
-    //path "*.csv", emit: submission_log
+    path "*.csv", emit: submission_log
 }

--- a/modules/local/fetch_submission/main.nf
+++ b/modules/local/fetch_submission/main.nf
@@ -44,6 +44,6 @@ process FETCH_SUBMISSION {
 
     """
     output:
-    path "${validated_meta_path.getBaseName()}", emit: submission_files
+    //path "${validated_meta_path.getBaseName()}", emit: submission_files
     path "${validated_meta_path.getBaseName()}/*.csv", emit: submission_report
 }

--- a/modules/local/fetch_submission/main.nf
+++ b/modules/local/fetch_submission/main.nf
@@ -45,5 +45,5 @@ process FETCH_SUBMISSION {
     """
     output:
     path "${validated_meta_path.getBaseName()}", emit: submission_files
-    path "*.csv", emit: submission_log
+    path "${validated_meta_path.getBaseName()}/*.csv", emit: submission_report
 }

--- a/modules/local/general_util/wait/main.nf
+++ b/modules/local/general_util/wait/main.nf
@@ -15,7 +15,7 @@ process WAIT {
     
 
     input:
-        val submission_signal
+        //val submission_signal
         val wait_time
 
     script:

--- a/modules/local/initial_submission/main.nf
+++ b/modules/local/initial_submission/main.nf
@@ -15,6 +15,7 @@ process SUBMISSION {
     input:
     tuple val(meta), path(validated_meta_path), path(fasta_path), path(fastq_1), path(fastq_2), path(annotations_path)
     path submission_config
+    val submission_mode
 
     // define the command line arguments based on the value of params.submission_test_or_prod, params.send_submission_email
     def test_flag = params.submission_prod_or_test == 'test' ? '--test' : ''
@@ -26,7 +27,7 @@ process SUBMISSION {
     script:
     """     
     submission_new.py \
-        --submit \
+        --$submission_mode \
         --submission_name $meta.id \
         --config_file $submission_config  \
         --metadata_file $validated_meta_path \

--- a/modules/local/initial_submission/main.nf
+++ b/modules/local/initial_submission/main.nf
@@ -45,5 +45,5 @@ process SUBMISSION {
     """
     output:
     path "${validated_meta_path.getBaseName()}", emit: submission_files
-    //path "*.csv", emit: submission_log
+    //path ""${validated_meta_path.getBaseName()}/*.csv", emit: submission_report
 }

--- a/modules/local/update_submission/main.nf
+++ b/modules/local/update_submission/main.nf
@@ -44,5 +44,5 @@ process UPDATE_SUBMISSION {
     """
     output:
     path "${validated_meta_path.getBaseName()}", emit: submission_files
-    path "*.csv", emit: submission_log
+    //path ""${validated_meta_path.getBaseName()}/*.csv", emit: submission_report
 }

--- a/modules/local/update_submission/main.nf
+++ b/modules/local/update_submission/main.nf
@@ -12,7 +12,6 @@ process UPDATE_SUBMISSION {
         'staphb/tostadas:latest' : 'staphb/tostadas:latest' }"
 
     input:
-    val wait_time
     tuple val(meta), path(validated_meta_path), path(fasta_path), path(fastq_1), path(fastq_2), path(annotations_path)
     path submission_config
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -60,11 +60,12 @@ params {
     biosample              = true
     submission_mode        = 'ftp' // 'ftp' or 'sftp'
     submission_output_dir  = "submission_outputs"
-    submission_wait_time   = 380 // time in seconds
-    submission_config      = "${projectDir}/bin/config_files/<your-ncbi-config>.yaml"
     submission_prod_or_test = "test" // "prod" if submitting
+    submission_config      = "${projectDir}/bin/config_files/<your-ncbi-config>.yaml"
+    submission_wait_time   = 380 // time in seconds
     send_submission_email  = false 
     update_submission      = false
+    fetch_reports_only     = false // only try to fetch reports
 
     // general params
     help                     = false

--- a/subworkflows/local/submission.nf
+++ b/subworkflows/local/submission.nf
@@ -17,34 +17,60 @@ workflow INITIAL_SUBMISSION {
         submission_ch // meta.id, tsv, fasta, fastq1, fastq2, gff
         submission_config
         wait_time
-    
+
     main:
-        if ( params.update_submission == false ) {
+        // Declare channels to dynamically handle conditional process outputs
+        Channel.empty().set { submission_files }    // Default for SUBMISSION output
+        Channel.empty().set { update_files }        // Default for UPDATE_SUBMISSION output
+        Channel.empty().set { fetched_reports }     // Default for FETCH_SUBMISSION output
+        // actual process to initiate wait 
+        //WAIT ( SUBMISSION.out.submission_files.collect(), wait_time )
+        WAIT ( wait_time )
+
+        if ( params.fetch_reports_only == true ) {
+            // Check if submission folder exists and run report fetching module
+            submission_ch
+                    .map { meta, validated_meta_path, fasta_path, fastq_1, fastq_2, annotations_path -> 
+                        def folder_path = file("${params.output_dir}/${params.submission_output_dir}/${meta.id}")
+                        if (!folder_path.exists()) {
+                            throw new IllegalStateException("Submission folder does not exist for ID: ${meta.id}")
+                        }
+                        // Return the tuple unchanged if the folder exists
+                        return tuple(meta, validated_meta_path, fasta_path, fastq_1, fastq_2, annotations_path)
+                    }
+                    .set { valid_submission_ch } // Create a new validated channel
+
+            FETCH_SUBMISSION ( WAIT.out, valid_submission_ch, submission_config )
+                .set { fetched_reports }
+        }
+
+        else if ( params.update_submission == false ) {
             // submit the files to database of choice
             SUBMISSION ( submission_ch, submission_config )
-                
-            // actual process to initiate wait 
-            WAIT ( SUBMISSION.out.submission_files.collect(), wait_time )
+                .set { submission_files }
 
             // try to fetch & parse the report.xml
-            // todo: need to incorporate WAIT.out somehow
             // todo: this maybe doesn't need to take all the inputs from submission (or maybe doesn't need to be a separate module)
             FETCH_SUBMISSION ( WAIT.out, submission_ch, submission_config )
+                .set { fetched_reports }
         }
 
         // if params.update_submission is true, update an existing submission
         else if ( params.update_submission == true ) {
             // process for updating the submitted samples
-            // todo: update to take the csv output from FETCH_SUBMISSION
             UPDATE_SUBMISSION ( submission_ch, submission_config )
+                .set { update_files }
 
             // try to fetch & parse the report.xml
-            // todo: need to incorporate WAIT.out somehow
             FETCH_SUBMISSION ( WAIT.out, submission_ch, submission_config )
+                .set { fetched_reports }
         }
         
     emit:
-        submission_files = SUBMISSION.out.submission_files
+        submission_files = submission_files
+        update_files = update_files
+        fetched_reports = fetched_reports
+        //submission_files = SUBMISSION.out.submission_files
         //submission_log = SUBMISSION.out.submission_log
 
         //to do: add GISAID module

--- a/subworkflows/local/submission.nf
+++ b/subworkflows/local/submission.nf
@@ -34,7 +34,8 @@ workflow INITIAL_SUBMISSION {
 
         // if params.update_submission is true, update an existing submission
         else if ( params.update_submission == true ) {
-             // process for updating the submitted samples
+            // process for updating the submitted samples
+            // todo: update to take the csv output from FETCH_SUBMISSION
             UPDATE_SUBMISSION ( submission_ch, submission_config )
 
             // try to fetch & parse the report.xml

--- a/subworkflows/local/submission.nf
+++ b/subworkflows/local/submission.nf
@@ -7,7 +7,8 @@
 */
 
 include { SUBMISSION                                    } from '../../modules/local/initial_submission/main'
-//include { UPDATE_SUBMISSION                             } from '../../modules/local/update_submission/main'
+include { FETCH_SUBMISSION                              } from '../../modules/local/fetch_submission/main'
+include { UPDATE_SUBMISSION                             } from '../../modules/local/update_submission/main'
 include { WAIT                                          } from '../../modules/local/general_util/wait/main'
 include { MERGE_UPLOAD_LOG                              } from "../../modules/local/general_util/merge_upload_log/main"
 
@@ -20,29 +21,30 @@ workflow INITIAL_SUBMISSION {
     main:
         if ( params.update_submission == false ) {
             // submit the files to database of choice
-            SUBMISSION ( submission_ch, submission_config, Channel.of("submit") )
+            SUBMISSION ( submission_ch, submission_config )
                 
             // actual process to initiate wait 
             WAIT ( SUBMISSION.out.submission_files.collect(), wait_time )
 
             // try to fetch & parse the report.xml
             // todo: need to incorporate WAIT.out somehow
-            SUBMISSION ( submission_ch, submission_config, Channel.of("fetch") )
+            // todo: this maybe doesn't need to take all the inputs from submission (or maybe doesn't need to be a separate module)
+            FETCH_SUBMISSION ( WAIT.out, submission_ch, submission_config )
         }
 
         // if params.update_submission is true, update an existing submission
         else if ( params.update_submission == true ) {
              // process for updating the submitted samples
-            SUBMISSION ( submission_ch, submission_config, Channel.of("update") )
+            UPDATE_SUBMISSION ( submission_ch, submission_config )
 
             // try to fetch & parse the report.xml
             // todo: need to incorporate WAIT.out somehow
-            SUBMISSION ( submission_ch, submission_config, Channel.of("fetch") )
+            FETCH_SUBMISSION ( WAIT.out, submission_ch, submission_config )
         }
         
     emit:
-        submission_files = UPDATE_SUBMISSION.out.submission_files
-        //submission_log = UPDATE_SUBMISSION.out.submission_log
+        submission_files = SUBMISSION.out.submission_files
+        //submission_log = SUBMISSION.out.submission_log
 
         //to do: add GISAID module
 }

--- a/subworkflows/local/submission.nf
+++ b/subworkflows/local/submission.nf
@@ -7,7 +7,7 @@
 */
 
 include { SUBMISSION                                    } from '../../modules/local/initial_submission/main'
-include { UPDATE_SUBMISSION                             } from '../../modules/local/update_submission/main'
+//include { UPDATE_SUBMISSION                             } from '../../modules/local/update_submission/main'
 include { WAIT                                          } from '../../modules/local/general_util/wait/main'
 include { MERGE_UPLOAD_LOG                              } from "../../modules/local/general_util/merge_upload_log/main"
 
@@ -18,15 +18,28 @@ workflow INITIAL_SUBMISSION {
         wait_time
     
     main:
-        // submit the files to database of choice (after fixing config and getting wait time) 
-        SUBMISSION ( submission_ch, submission_config )
-            
-        // actual process to initiate wait 
-        WAIT ( SUBMISSION.out.submission_files.collect(), wait_time )
+        if ( params.update_submission == false ) {
+            // submit the files to database of choice
+            SUBMISSION ( submission_ch, submission_config, Channel.of("submit") )
+                
+            // actual process to initiate wait 
+            WAIT ( SUBMISSION.out.submission_files.collect(), wait_time )
 
-        // process for updating the submitted samples
-        UPDATE_SUBMISSION ( WAIT.out, submission_ch, submission_config )
+            // try to fetch & parse the report.xml
+            // todo: need to incorporate WAIT.out somehow
+            SUBMISSION ( submission_ch, submission_config, Channel.of("fetch") )
+        }
 
+        // if params.update_submission is true, update an existing submission
+        else if ( params.update_submission == true ) {
+             // process for updating the submitted samples
+            SUBMISSION ( submission_ch, submission_config, Channel.of("update") )
+
+            // try to fetch & parse the report.xml
+            // todo: need to incorporate WAIT.out somehow
+            SUBMISSION ( submission_ch, submission_config, Channel.of("fetch") )
+        }
+        
     emit:
         submission_files = UPDATE_SUBMISSION.out.submission_files
         //submission_log = UPDATE_SUBMISSION.out.submission_log


### PR DESCRIPTION
## Description
This reworks the update_submissions module so that it is used for re-submitting updates to BioSample, etc.  Now the `--update_submissions` flag is used to submit an updated metadata file.  It requires the submission_report.csv to be present in its expected location (with valid accession IDs) and will upload new submission/xml files with updated metadata and the accession IDs. 

There is a new fetch_submissions module that runs after initial_submissions.  It runs after an initial submission or an update submission, but can also be run independently with fetch_reports_only = true.

The subworkflow was re-worked a bit to allow these three independent submission-related functionalities:
* Run an initial submission (and try to fetch the reports immediately)
* Run an updated submission (submit a new metadata file, and try to fetch the reports immediately)
* Try to fetch reports for an existing submission (the workflow will look for this submission in output_dir/submission_files/metadata_file_basename).

## Checklist

**Go Through Checklist Below and Place A :heavy_check_mark: (X Inside the Box) if Completed**

#### General Checks

* [] Have you run appropriate tests (unit/integration/end-to-end) to check logic across run environments (Conda/Docker/Singularity on Scicomp/AWS/NF Tower/Local)?
Checked test profile on Scicomp, with Singularity
    
    For each relevant configuration:

    * Can the program run completely through without erroring out?
    * Does it produce the expected outputs, given the inputs provided? 

* [x] Have you conducted proper linting procedures?
    * Numpy formatted docstrings for functions
    * Comments explaining lines of code
    * Consistent and intuitive naming conventions for variables, functions, classes, methods, attributes, and scripts
    * Single empty line between class functions, two lines between non-class functions, and two lines between imports and code body
    * Camel case formatting for class names

* [] Have you updated existing documentation (README.md, etc.) or created new ones within docs?
I have not done this yet. Should be completed before merging the PR.
We need to add fetch_reports_only flag, and explain that's just for fetching the report.xml from NCBI server if, for instance, it wasn't fetched after the initial submission ran.  And we need to clarify that update_submission is for updating a submission you've already made - it requires the submission_report.csv (with valid accession IDs) and will upload new submission/xml files with updated metadata and the accession IDs.  The IDs are required for NCBI to link the record to the original one and update it (otherwise it gets submitted as a new record).

#### CDC Checks

* [x] Did you check for sensitive data, and remove any?
* [x] If you added or modified HTML, did you check that it was 508 compliant?

Are additional approvals needed for this change? If so, please mention them below:

Are there potential vulnerabilities or licensing issues with any new dependencies introduced? If so, please mention them below:




