### PR TITLE
For verbose (v) and short (s) flags, set valid MM DD dates

### DIFF
--- a/bin/validate_metadata.py
+++ b/bin/validate_metadata.py
@@ -527,9 +527,9 @@ class ValidateChecks:
 					# Extract date components
 					year, month, day, *_ = match.groups()
 					if not month:
-						month = "00"
+						month = "01"
 					if not day:
-						day = "00"
+						day = "01"
 
 					# Check if the year is only two digits
 					if len(year) == 2:


### PR DESCRIPTION
## Description
In metadata validation, the verbose and short flags were setting invalid month and/or date (00) so these were changed to 01.

## Checklist

**Go Through Checklist Below and Place A :heavy_check_mark: (X Inside the Box) if Completed**

#### General Checks

* [] Have you run appropriate tests (unit/integration/end-to-end) to check logic across run environments (Conda/Docker/Singularity on Scicomp/AWS/NF Tower/Local)?

    
    For each relevant configuration:

    * Can the program run completely through without erroring out?
    * Does it produce the expected outputs, given the inputs provided? 

* [] Have you conducted proper linting procedures?
    * Numpy formatted docstrings for functions
    * Comments explaining lines of code
    * Consistent and intuitive naming conventions for variables, functions, classes, methods, attributes, and scripts
    * Single empty line between class functions, two lines between non-class functions, and two lines between imports and code body
    * Camel case formatting for class names

* [] Have you updated existing documentation (README.md, etc.) or created new ones within docs?

#### CDC Checks

* [] Did you check for sensitive data, and remove any?
* [] If you added or modified HTML, did you check that it was 508 compliant?

Are additional approvals needed for this change? If so, please mention them below:

Are there potential vulnerabilities or licensing issues with any new dependencies introduced? If so, please mention them below:




