### PR TITLE
Move the updated_meta_path default assignment to the workflow because global reassignment isn't being recognized

### DIFF
--- a/nextflow.config
+++ b/nextflow.config
@@ -65,7 +65,7 @@ params {
     send_submission_email        = false 
     update_submission            = false
     biosample_fields_key         = "${projectDir}/assets/biosample_fields_key.yaml"
-    updated_meta_path            = "" // pipeline will find this in final_submission_output_dir if it exists
+    updated_meta_path            = null // pipeline will find this in final_submission_output_dir if it exists
     dry_run                      = false // prints ftp paths files will be uploaded to
 
     // General params


### PR DESCRIPTION
## Description
If you run the genbank workflow after biosample_and_sra, and you forget to specify `--updated_meta_path`, it will default to the one generated by biosample_and_sra (as long as you've provided `meta_path`.

## Checklist

**Go Through Checklist Below and Place A :heavy_check_mark: (X Inside the Box) if Completed**

#### General Checks

* [] Have you run appropriate tests (unit/integration/end-to-end) to check logic across run environments (Conda/Docker/Singularity on Scicomp/AWS/NF Tower/Local)?

    
    For each relevant configuration:

    * Can the program run completely through without erroring out?
    * Does it produce the expected outputs, given the inputs provided? 

* [] Have you conducted proper linting procedures?
    * Numpy formatted docstrings for functions
    * Comments explaining lines of code
    * Consistent and intuitive naming conventions for variables, functions, classes, methods, attributes, and scripts
    * Single empty line between class functions, two lines between non-class functions, and two lines between imports and code body
    * Camel case formatting for class names

* [] Have you updated existing documentation (README.md, etc.) or created new ones within docs?

#### CDC Checks

* [] Did you check for sensitive data, and remove any?
* [] If you added or modified HTML, did you check that it was 508 compliant?

Are additional approvals needed for this change? If so, please mention them below:

Are there potential vulnerabilities or licensing issues with any new dependencies introduced? If so, please mention them below:




