### PR TITLE
Remove the accidental 'def' in main.nf Channel initialization

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -57,7 +57,7 @@ workflow FETCH_ACCESSIONS_WORKFLOW {
     } // meta = batch_id, dir = path to batch_id dir
     log.info "Fetching report.xml files for submissions in ${params.outdir}/${params.metadata_basename}/${params.submission_outdir}"
     // use a dummy channel placeholder in place of the WAIT utility, which isn't used in this workflow, 
-    def dummy_wait = Channel.value(true)
+    dummy_wait = Channel.value(true)
     AGGREGATE_SUBMISSIONS(batches,
                           params.submission_config,
                           file("${params.outdir}/${params.metadata_basename}/${params.validation_outdir}/validated_metadata_all_samples.tsv"), dummy_wait)


### PR DESCRIPTION
## Description
I had accidentally created a function (line 60 of main.nf), which caused a scoping conflict as Nextflow interpreted that I was redefining Channel.  Removing 'def' fixes this issue.  I'm not sure why it never caused an issue on my system, but that meant I didn't catch it.

`def dummy_wait = Channel.value(true)` -> `dummy_wait = Channel.value(true)`

## Checklist

**Go Through Checklist Below and Place A :heavy_check_mark: (X Inside the Box) if Completed**

#### General Checks

* [x] Have you run appropriate tests (unit/integration/end-to-end) to check logic across run environments (Conda/Docker/Singularity on Scicomp/AWS/NF Tower/Local)?

    
    For each relevant configuration:

    * Can the program run completely through without erroring out?
    * Does it produce the expected outputs, given the inputs provided? 

* [x] Have you conducted proper linting procedures?
    * Numpy formatted docstrings for functions
    * Comments explaining lines of code
    * Consistent and intuitive naming conventions for variables, functions, classes, methods, attributes, and scripts
    * Single empty line between class functions, two lines between non-class functions, and two lines between imports and code body
    * Camel case formatting for class names

* [N/A] Have you updated existing documentation (README.md, etc.) or created new ones within docs?

#### CDC Checks

* [N/A] Did you check for sensitive data, and remove any?
* [N/A] If you added or modified HTML, did you check that it was 508 compliant?

Are additional approvals needed for this change? If so, please mention them below:

Are there potential vulnerabilities or licensing issues with any new dependencies introduced? If so, please mention them below:




