### PR TITLE
Fix PREP/UPDATE/SUBMIT_SUBMISSION for cloud executors (val→path staging, setup_logging, optional log outputs)

### DIFF
--- a/bin/submission_helper.py
+++ b/bin/submission_helper.py
@@ -25,15 +25,22 @@ from email.mime.multipart import MIMEMultipart
 from email.mime.application import MIMEApplication
 
 def setup_logging(log_file="submission.log", level=logging.INFO):
-	if not logging.getLogger().handlers:
-		logging.basicConfig(
-			level=level,
-			format="[%(levelname)s] %(message)s",
-			handlers=[
-				logging.FileHandler(log_file, mode="a"),
-				logging.StreamHandler()
-			]
-		)
+	# force=True: reconfigure the root logger even if handlers already exist.
+	# The prior guard `if not logging.getLogger().handlers` silently no-op'd
+	# inside the staphb/tostadas container where an earlier import pre-
+	# registers a handler, so FileHandler was never attached and the log
+	# file the Nextflow module declares as an output was never created,
+	# causing PREP_SUBMISSION and UPDATE_SUBMISSION to fail on cloud
+	# executors when Nextflow tried to stage the (nonexistent) log file.
+	logging.basicConfig(
+		level=level,
+		format="[%(levelname)s] %(message)s",
+		handlers=[
+			logging.FileHandler(log_file, mode="a"),
+			logging.StreamHandler()
+		],
+		force=True
+	)
 
 def symlink_or_copy(src, dst, copy=False):
 	if not os.path.exists(dst):

--- a/modules/local/prep_submission/main.nf
+++ b/modules/local/prep_submission/main.nf
@@ -38,15 +38,15 @@ process PREP_SUBMISSION {
     // walk samples in order and pop the next entry from each file iterator
     // whenever the sample declares that key. Referencing the staged path
     // (rather than the original workDir URI stored in the samples map) is
-    // what makes cloud executors work: on Google Batch the URI resolves to
-    // a container-local /tostadas-work/<hash>/... path that doesn't exist.
+    // what makes cloud executors work: the raw URI resolves to a
+    // container-local /tostadas-work/<hash>/... path that doesn't exist.
     //
     // Nextflow binds `path` inputs to a Path object when it receives a
     // single file and to a List when it receives multiple. Calling
     // `.iterator()` on a Path iterates its NAME SEGMENTS (e.g., "fastas",
-    // then "AF266288_cleaned.fsa"), so we must coerce to a list before
-    // iterating. Empty lists (batches with no files of that type) stay as
-    // empty lists and never get iterated because the sample map doesn't
+    // then the basename), so we must coerce to a list before iterating.
+    // Empty lists (batches with no files of that type) stay as empty
+    // lists and never get iterated because the sample map doesn't
     // declare that key.
     def asList = { v -> (v instanceof List) ? v : (v ? [v] : []) }
     def fasta_iter = asList(fastas).iterator()

--- a/modules/local/prep_submission/main.nf
+++ b/modules/local/prep_submission/main.nf
@@ -40,11 +40,20 @@ process PREP_SUBMISSION {
     // (rather than the original workDir URI stored in the samples map) is
     // what makes cloud executors work: on Google Batch the URI resolves to
     // a container-local /tostadas-work/<hash>/... path that doesn't exist.
-    def fasta_iter = fastas.iterator()
-    def gff_iter   = gffs.iterator()
-    def fq1_iter   = fq1s.iterator()
-    def fq2_iter   = fq2s.iterator()
-    def nnp_iter   = nnps.iterator()
+    //
+    // Nextflow binds `path` inputs to a Path object when it receives a
+    // single file and to a List when it receives multiple. Calling
+    // `.iterator()` on a Path iterates its NAME SEGMENTS (e.g., "fastas",
+    // then "AF266288_cleaned.fsa"), so we must coerce to a list before
+    // iterating. Empty lists (batches with no files of that type) stay as
+    // empty lists and never get iterated because the sample map doesn't
+    // declare that key.
+    def asList = { v -> (v instanceof List) ? v : (v ? [v] : []) }
+    def fasta_iter = asList(fastas).iterator()
+    def gff_iter   = asList(gffs).iterator()
+    def fq1_iter   = asList(fq1s).iterator()
+    def fq2_iter   = asList(fq2s).iterator()
+    def nnp_iter   = asList(nnps).iterator()
 
     def sample_args_list = samples.collect { sample ->
         def s = [

--- a/modules/local/prep_submission/main.nf
+++ b/modules/local/prep_submission/main.nf
@@ -11,9 +11,9 @@ process PREP_SUBMISSION {
         'docker.io/staphb/tostadas:latest' : 'docker.io/staphb/tostadas:latest' }"
 
     input:
-    tuple val(meta), val(samples), val(enabledDatabases)
+    tuple val(meta), val(samples), val(enabledDatabases), path(batch_tsv), path(fastas, stageAs: 'fastas/*'), path(gffs, stageAs: 'gffs/*'), path(fq1s, stageAs: 'fq1s/*'), path(fq2s, stageAs: 'fq2s/*'), path(nnps, stageAs: 'nnps/*')
     path(submission_config)
-    
+
     output:
     tuple val(meta), path("${meta.batch_id}"), emit: submission_files
     path("${meta.batch_id}/prep_submission.log"), emit: submission_log, optional: true
@@ -31,15 +31,29 @@ process PREP_SUBMISSION {
     def wastewater = params.biosample_pkg == 'wastewater' ? '--wastewater' : ''
     def strip_pub = params.strip_pub_block == true ? '--strip_pub_block' : ''
 
-    // Assemble per-sample arguments, quoting paths in case of spaces
+    // Nextflow stages the per-file-type path lists (fastas/gffs/fq1s/fq2s/
+    // nnps) into subdirectories in the work directory. Upstream workflows
+    // emit each list in the same order as `samples`, dropping entries where
+    // a sample lacks that file. To rebuild the per-sample argument list we
+    // walk samples in order and pop the next entry from each file iterator
+    // whenever the sample declares that key. Referencing the staged path
+    // (rather than the original workDir URI stored in the samples map) is
+    // what makes cloud executors work: on Google Batch the URI resolves to
+    // a container-local /tostadas-work/<hash>/... path that doesn't exist.
+    def fasta_iter = fastas.iterator()
+    def gff_iter   = gffs.iterator()
+    def fq1_iter   = fq1s.iterator()
+    def fq2_iter   = fq2s.iterator()
+    def nnp_iter   = nnps.iterator()
+
     def sample_args_list = samples.collect { sample ->
         def s = [
             "sample_id=${sample.meta.sample_id}",
-            sample.get("fq1")      ? "fq1=${sample.fq1}"       : null,
-            sample.get("fq2")      ? "fq2=${sample.fq2}"       : null,
-            sample.get("nnp")      ? "nnp=${sample.nanopore}"  : null,
-            sample.get("fasta")    ? "fasta=${sample.fasta}"   : null,
-            sample.get("gff")      ? "gff=${sample.gff}"       : null
+            sample.get("fq1")       ? "fq1=${fq1_iter.next()}"     : null,
+            sample.get("fq2")       ? "fq2=${fq2_iter.next()}"     : null,
+            sample.get("nanopore")  ? "nnp=${nnp_iter.next()}"     : null,
+            sample.get("fasta")     ? "fasta=${fasta_iter.next()}" : null,
+            sample.get("gff")       ? "gff=${gff_iter.next()}"     : null
         ].findAll { it != null }
         .join(',')
         return "\"${s}\""
@@ -50,7 +64,7 @@ process PREP_SUBMISSION {
     submission_prep.py \
         --submission_name ${meta.batch_id} \
         --config_file $submission_config  \
-        --metadata_file ${meta.batch_tsv} \
+        --metadata_file $batch_tsv \
         --identifier ${params.metadata_basename} \
         --species $params.organism_type \
         --mol_type '$params.mol_type' \

--- a/modules/local/prep_submission/main.nf
+++ b/modules/local/prep_submission/main.nf
@@ -16,7 +16,14 @@ process PREP_SUBMISSION {
 
     output:
     tuple val(meta), path("${meta.batch_id}"), emit: submission_files
-    path("${meta.batch_id}/prep_submission.log"), emit: submission_log, optional: true
+    // Removed: path("${meta.batch_id}/prep_submission.log"), emit: submission_log, optional: true
+    // On Nextflow's Google Batch executor, `optional: true` isn't fully
+    // respected during output staging: staging attempts `mv` on the
+    // declared file even when it doesn't exist, failing the task with
+    // `mv: cannot stat '.../prep_submission.log'`. The log file (when
+    // created by submission_prep.py) is still emitted as part of the
+    // catch-all `path("${meta.batch_id}")` output above, so nothing
+    // downstream needs the separate emit.
 
     when:
     "sra" in enabledDatabases || "genbank" in enabledDatabases || "biosample" in enabledDatabases

--- a/modules/local/submit_submission/main.nf
+++ b/modules/local/submit_submission/main.nf
@@ -16,7 +16,12 @@ process SUBMIT_SUBMISSION {
 
     output:
     tuple val(meta), path("${meta.batch_id}"), emit: submission_batch_folder
-    path("${meta.batch_id}/submission.log"), emit: submission_log, optional: true
+    // Removed: path("${meta.batch_id}/submission.log"), emit: submission_log, optional: true
+    // Same rationale as prep_submission/main.nf: Nextflow's Google Batch
+    // executor doesn't fully respect `optional: true` on path outputs;
+    // staging attempts `mv` on a nonexistent file and fails the task.
+    // The log (when produced) is still captured by the catch-all
+    // `path("${meta.batch_id}")` directory output above.
 
     script:
     def test_flag = params.prod_submission == false ? '--test' : ''

--- a/modules/local/update_submission/main.nf
+++ b/modules/local/update_submission/main.nf
@@ -37,7 +37,7 @@ process UPDATE_SUBMISSION {
 
     // batch_tsv is now a Nextflow-staged path input so it resolves inside
     // the container on cloud executors; using `${meta.batch_tsv}` (a raw
-    // workDir URI string) fails with FileNotFoundError on Google Batch.
+    // workDir URI string) fails with FileNotFoundError on those executors.
     """
     submission_update.py \
         --submission_folder ${original_submissions_dir} \

--- a/modules/local/update_submission/main.nf
+++ b/modules/local/update_submission/main.nf
@@ -18,7 +18,9 @@ process UPDATE_SUBMISSION {
 
     output:
     tuple val(meta), path("${meta.batch_id}_biosample_update_[0-9]*"), emit: submission_batch_folder
-    path("${meta.batch_id}/update_submission.log"), emit: submission_log, optional: true
+    // Removed: path("${meta.batch_id}/update_submission.log"), emit: submission_log, optional: true
+    // Same rationale as prep_submission/main.nf: `optional: true` isn't
+    // fully respected during Nextflow Google Batch output staging.
 
     when:
     "sra" in enabledDatabases || "genbank" in enabledDatabases || "biosample" in enabledDatabases

--- a/modules/local/update_submission/main.nf
+++ b/modules/local/update_submission/main.nf
@@ -12,10 +12,10 @@ process UPDATE_SUBMISSION {
         'docker.io/staphb/tostadas:latest' : 'docker.io/staphb/tostadas:latest' }"
 
     input:
-    tuple val(meta), val(samples), val(enabledDatabases)
+    tuple val(meta), val(samples), val(enabledDatabases), path(batch_tsv)
     path(original_submissions_dir)
     path(submission_config)
-    
+
     output:
     tuple val(meta), path("${meta.batch_id}_biosample_update_[0-9]*"), emit: submission_batch_folder
     path("${meta.batch_id}/update_submission.log"), emit: submission_log, optional: true
@@ -35,16 +35,19 @@ process UPDATE_SUBMISSION {
     }
     def sample_args = sample_args_list.collect { "--sample ${it}" }.join(' ')
 
+    // batch_tsv is now a Nextflow-staged path input so it resolves inside
+    // the container on cloud executors; using `${meta.batch_tsv}` (a raw
+    // workDir URI string) fails with FileNotFoundError on Google Batch.
     """
     submission_update.py \
         --submission_folder ${original_submissions_dir} \
         --submission_name ${meta.batch_id} \
         --config_file ${submission_config}  \
-        --metadata_file ${meta.batch_tsv} \
+        --metadata_file $batch_tsv \
         --identifier ${params.metadata_basename} \
         --outdir  ${meta.batch_id} \
         --submission_mode ${params.submission_mode} \
         $test_flag \
-        $dry_run 
+        $dry_run
     """
 }

--- a/subworkflows/local/submission.nf
+++ b/subworkflows/local/submission.nf
@@ -11,7 +11,7 @@ include { SUBMIT_SUBMISSION     } from '../../modules/local/submit_submission/ma
 
 workflow SUBMISSION {
     take:
-        submission_ch         // (meta: [batch_id: ..., batch_tsv: ...], samples: [ [meta, fasta, fq1, fq2, nnp, gff], ... ]), enabledDatabases (list)
+        submission_ch         // tuple(meta, samples, enabledDatabases, batch_tsv, fastas, gffs, fq1s, fq2s, nnps) — file lists are staged into the PREP_SUBMISSION container by declaring them as `path` inputs; sample paths must not be resolved from the raw workDir URI stored in the samples map (fails on cloud executors)
         submission_config
 
     main:

--- a/workflows/biosample_and_sra.nf
+++ b/workflows/biosample_and_sra.nf
@@ -122,11 +122,25 @@ workflow BIOSAMPLE_AND_SRA {
 					batch_tsv: sample_maps[0].meta.batch_tsv
 				]
 
-				return tuple(meta, sample_maps, enabledDatabases as List)
+				// Emit files as separate list items so PREP_SUBMISSION can
+				// declare them as `path` inputs and Nextflow stages them
+				// into the container. See genbank.nf for the full rationale
+				// (cloud executors reject the raw workDir URI strings that
+				// come out of the val-typed samples map).
+				def batch_tsv_file = sample_maps[0].meta.batch_tsv
+				def fasta_files    = []
+				def gff_files      = []
+				def fq1_files      = sample_maps.collect { it.fq1 }.findAll { it != null }
+				def fq2_files      = sample_maps.collect { it.fq2 }.findAll { it != null }
+				def nnp_files      = sample_maps.collect { it.nanopore }.findAll { it != null }
+
+				return tuple(meta, sample_maps, enabledDatabases as List,
+				             batch_tsv_file, fasta_files, gff_files,
+				             fq1_files, fq2_files, nnp_files)
 			}
 
 		SUBMISSION(
-			submission_batch_ch, // meta: [sample_id, batch_id, batch_tsv], samples: [ [meta, fq1, fq2, nnp], ... ]), enabledDatabases (list)
+			submission_batch_ch, // tuple(meta, samples, enabledDatabases, batch_tsv, fastas, gffs, fq1s, fq2s, nnps)
 			params.submission_config
 		)
 	}

--- a/workflows/biosample_update.nf
+++ b/workflows/biosample_update.nf
@@ -68,8 +68,13 @@ workflow BIOSAMPLE_UPDATE {
     rebatch_ch = REBATCH_METADATA.out.rebatch_tuple
         .map { tsv_file, json_file ->
             def parsed = new groovy.json.JsonSlurper().parseText(json_file.text)
-            parsed.meta.batch_tsv = tsv_file.toString()  // path is guaranteed to exist
-            tuple(parsed.meta, parsed.samples, parsed.enabled)
+            parsed.meta.batch_tsv = tsv_file.toString()  // retained for backward compat; UPDATE_SUBMISSION now reads the staged path instead
+            // Emit tsv_file as a separate tuple item so UPDATE_SUBMISSION
+            // can declare it as `path(batch_tsv)` and Nextflow stages it
+            // into the container. The prior `meta.batch_tsv` (a raw
+            // workDir URI string) fails on cloud executors where the
+            // referenced path doesn't exist inside the task container.
+            tuple(parsed.meta, parsed.samples, parsed.enabled, tsv_file)
         }
 
     if (params.dry_run) {

--- a/workflows/genbank.nf
+++ b/workflows/genbank.nf
@@ -132,14 +132,34 @@ workflow GENBANK {
                     batch_id : batch_id,
                     batch_tsv: samples[0].meta.batch_tsv
                 ]
-                def enabledDatabases = missingFasta ? [] : ['genbank'] 
-                return tuple(meta, samples, enabledDatabases)
+                def enabledDatabases = missingFasta ? [] : ['genbank']
+
+                // Emit files as separate list items so PREP_SUBMISSION can
+                // declare them as `path` inputs and Nextflow stages them
+                // into the container. Passing paths only through the
+                // `samples` map (a `val` input) leaves them as raw
+                // workDir URIs, which fail on cloud executors where the
+                // referenced /tostadas-work/<hash>/... path doesn't exist
+                // inside the task container. Lists are in the same order
+                // as `samples`, with entries omitted where a sample lacks
+                // that file; the module walks samples in the same order
+                // to zip them back together.
+                def batch_tsv_file = samples[0].meta.batch_tsv
+                def fasta_files    = samples.collect { it.fasta }.findAll { it != null }
+                def gff_files      = samples.collect { it.gff }.findAll { it != null }
+                def fq1_files      = []
+                def fq2_files      = []
+                def nnp_files      = []
+
+                return tuple(meta, samples, enabledDatabases,
+                             batch_tsv_file, fasta_files, gff_files,
+                             fq1_files, fq2_files, nnp_files)
             }
         }
-        
+
 
         // Run submission using the batch channel
-        SUBMISSION(submission_batch_ch, // meta: [sample_id, batch_id, batch_tsv], samples: [ [meta, fq1, fq2, nnp], ... ]), enabledDatabases (list)
+        SUBMISSION(submission_batch_ch, // tuple(meta, samples, enabledDatabases, batch_tsv, fastas, gffs, fq1s, fq2s, nnps)
                 params.submission_config)
 
 	emit:


### PR DESCRIPTION
## Description
**Please Describe the Bug(s) Fixed and/or the Feature(s) Added:**

Three related fixes for tostadas on cloud executors (validated on Google Batch via Seqera Platform; applies to any executor with a URI-shaped workDir). The original scope was the `FileNotFoundError` in `PREP_SUBMISSION` / `UPDATE_SUBMISSION`; two additional bugs surfaced during end-to-end validation and are fixed alongside.

### Fix 1: `PREP_SUBMISSION` and `UPDATE_SUBMISSION` — val vs path staging

`PREP_SUBMISSION` and `UPDATE_SUBMISSION` reference file paths through a val-typed meta/samples map (`${meta.batch_tsv}`, `${sample.fasta}`, etc.). Because those are `val` inputs and not `path` inputs, Nextflow doesn't stage the referenced files into the task container. On cloud executors the paths resolve to raw workDir URIs (`/tostadas-work/<hash>/...`) that don't exist inside the container, and both modules fail before the submission scripts ever run.

Example failure on a cloud executor:

    submission_prep.py --metadata_file /tostadas-work/<task-hash>/genbank/batch_1.tsv ...
    FileNotFoundError: '/tostadas-work/<task-hash>/genbank/batch_1.tsv'

(where `/tostadas-work/` is the workDir set in `nextflow.config` for the cloud executor)

**Fix:** lift each per-sample file type out of the meta/samples map into an explicit `path` input list. Nextflow then stages each list into a per-type subdirectory in the work dir, and the script walks samples in the same order the upstream workflow emitted them, popping the next entry from each file iterator whenever the sample declares that key. Same pattern used in 915d2b3 for `submission_config` staging in `METADATA_VALIDATION`. See commits `febfe53`, `2c2fe1b`, `c9980bb`.

### Fix 2: `setup_logging` silently no-ops when handlers pre-exist

`submission_helper.py::setup_logging` was guarded by `if not logging.getLogger().handlers:` and silently returned without configuring anything when handlers already existed. Inside the `staphb/tostadas` container an earlier import pre-registers a root-logger handler, so `FileHandler` was never attached and the `*.log` files that the Nextflow modules declare as outputs (`prep_submission.log`, `update_submission.log`, `submission.log`) were never actually written.

**Fix:** drop the guard and add `force=True` to `logging.basicConfig` so the root logger is unconditionally reconfigured. See commit `10e6544`.

### Fix 3: Drop optional log-file output declarations in PREP/UPDATE/SUBMIT_SUBMISSION

Even with Fix 2 applied, cloud-executor runs still failed with `mv: cannot stat '.../*.log': No such file or directory`. On the Google Batch executor, `optional: true` on `path` output declarations isn't fully respected during output staging — the staging step attempts `mv` on the declared file unconditionally and fails the task when the file isn't there.

**Fix:** remove the individual `submission_log` output declarations from `prep_submission/main.nf`, `update_submission/main.nf`, and `submit_submission/main.nf`. The catch-all `path("${meta.batch_id}")` directory output still captures the log file when produced, so downstream consumers don't lose it in successful runs. `fetch_reports/main.nf` was left as-is because it uses `optional: false` (log file is expected/required per the schema); with Fix 2, the log file should always exist by that point. See commit `383447d`.

### Drive-by fix

While in `PREP_SUBMISSION` I noticed the sample_args builder was checking `sample.get("nnp")` but referencing `sample.nanopore`. Upstream workflows populate the `"nanopore"` key, so the `"nnp"` check was always false and nanopore samples were silently omitted from `sample_args`. Fixed to check the correct `"nanopore"` key.

## Files touched

**Fix 1 (val/path staging):**

- `modules/local/prep_submission/main.nf` — tuple input now includes staged `batch_tsv` plus five path lists (`fastas`, `gffs`, `fq1s`, `fq2s`, `nnps`); script uses iterators to zip samples with staged files
- `modules/local/update_submission/main.nf` — tuple input includes staged `batch_tsv`; script references `$batch_tsv`
- `subworkflows/local/submission.nf` — updated `take` comment
- `workflows/genbank.nf` — `submission_batch_ch` now emits a 9-item tuple
- `workflows/biosample_and_sra.nf` — same shape (fq1/fq2/nnp populated instead of fasta/gff)
- `workflows/biosample_update.nf` — `rebatch_ch` tuple includes `tsv_file`

**Fix 2 (setup_logging force=True):**

- `bin/submission_helper.py` — drop guard, add `force=True`

**Fix 3 (drop optional log outputs):**

- `modules/local/prep_submission/main.nf`
- `modules/local/update_submission/main.nf`
- `modules/local/submit_submission/main.nf`

## Checklist

**Go Through Checklist Below and Place A :heavy_check_mark: (X Inside the Box) if Completed**

#### General Checks

* [x] Have you run appropriate tests (unit/integration/end-to-end) to check logic across run environments (Conda/Docker/Singularity on Scicomp/AWS/NF Tower/Local)?

    Validated end-to-end on **Docker + Google Batch (via Seqera Platform)** for the `genbank` workflow with all three fixes applied:

    - Single-sample measles VADR dry-run (`AF266288`, a public GenBank accession)
    - **8/8 pipeline tasks succeeded** (CREATE_BATCH_TSVS → GENBANK_VALIDATION → VADR_MODEL_SETUP → VADR_TRIM → VADR_ANNOTATION → VADR_POST_CLEANUP → PREP_SUBMISSION → SUBMIT_SUBMISSION)
    - Output artifacts confirmed: `.sqn`, `.tbl`, `.zip`, VADR reports
    - Generated `.sqn` opens with a proper `Seq-submit ::= {` ASN.1 header and populated contact/affiliation blocks

    Did **not** test Conda / Singularity / Scicomp / AWS / NF Tower / Local execution paths, nor the `biosample_and_sra` or `biosample_update` workflows (no biosample test data available in the environment). Those workflows use the same channel-wiring pattern as `genbank` and the fixes were applied identically, so they should work, but happy to gate on additional testing if the reviewer wants.

* [x] Have you conducted proper linting procedures?

    - Block comments added at each change explaining the WHY (why files need to be lifted out of val, why iterator coercion is needed, why the `setup_logging` guard is dropped, why the log outputs are removed)
    - Variable naming matches existing tostadas conventions
    - No Python formatting churn beyond the `setup_logging` change

* [ ] Have you updated existing documentation (README.md, etc.) or created new ones within docs?

    Bug fixes, not new features. Existing README doesn't need changes. Happy to add a "cloud executor support" note if the reviewer prefers.

#### CDC Checks

* [x] Did you check for sensitive data, and remove any?

    Confirmed: no infrastructure identifiers, credentials, or environment-specific paths in the diff or PR body. Comments use generic examples.

* [ ] If you added or modified HTML, did you check that it was 508 compliant?

    N/A — no HTML in this PR.

Are additional approvals needed for this change? If so, please mention them below:

Not that I'm aware of, but please flag if there are.

Are there potential vulnerabilities or licensing issues with any new dependencies introduced? If so, please mention them below:

No new dependencies introduced.
